### PR TITLE
Set action test to local source base dir

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -81,7 +81,7 @@ jobs:
         run: Test-ModuleManifest -Path ./src/PSWattTime/PSWattTime.psd1
 
       - name: Run the GitHub action in this commit
-        uses: cloudyspells/PSWattTime@main
+        uses: ./
         id: watttime_action
         with:
           azure_credential: ${{ secrets.AZURE_CREDENTIALS }}


### PR DESCRIPTION
## Description
The qa workflow now _really does use_ the action file from the current commit in testing. Previously it was stated it did, but this was found not to be true in implementation.

## Related Issue
- Bug #14 

## Motivation and Context
This change makes sure the main branch stays clean with versions of the GitHub action that have always been tested.

## How Has This Been Tested?
This has been tested by running the pipeline with the new filepath based reference

## Screenshots (if appropriate):
NA

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
