### PR TITLE
Fix datatype issue in percent output resulting in sorting issue

### DIFF
--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,3 +1,3 @@
 @{
-    ExcludeRules = @('PSAvoidUsingPlainTextForPassword')
+    ExcludeRules = @('PSAvoidUsingPlainTextForPassword','PSAvoidUsingUsernameAndPasswordParams')
 }

--- a/src/PSWattTime/PSWattTime.psd1
+++ b/src/PSWattTime/PSWattTime.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PSWattTime.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.4.0'
+ModuleVersion = '1.0.5.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -114,7 +114,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'Updates to documentation and PowerShell internal help'
+        ReleaseNotes = 'Fix return datatype for percent of each function'
 
         # Prerelease string of this module
         # Prerelease = ''

--- a/src/PSWattTime/PSWattTime.psm1
+++ b/src/PSWattTime/PSWattTime.psm1
@@ -90,6 +90,7 @@ function Get-WattTime {
         ba = $ba
     }
     $wattTime = Invoke-RestMethod -Uri 'https://api2.watttime.org/v2/index/' -Method Get -Headers $headers -Body $params -ContentType 'application/json'
+    $wattTime.percent = [int]($wattTime.percent)
     return $wattTime
 }
 

--- a/tests/PSWattTime.Tests/PSWattTime.Tests.ps1
+++ b/tests/PSWattTime.Tests/PSWattTime.Tests.ps1
@@ -102,7 +102,7 @@ Describe "PSWattTimeTests" {
         }
 
         It "Should return a PSCustomObject with a percent property with a value" {
-            $wattTime.percent | Should -BeOfType 'string'
+            $wattTime.percent | Should -BeOfType 'int'
         }
     }
 
@@ -141,7 +141,7 @@ Describe "PSWattTimeTests" {
         }
 
         It "Should return a PSCustomObject with a percent property with a value" {
-            $wattTime.percent | Should -BeOfType 'string'
+            $wattTime.percent | Should -BeOfType 'int'
         }
     }
     Context "When we register an account" {


### PR DESCRIPTION
## Description

This update fixes an issue with percent output of the API being of `string` data type, which gives issues in sorting. The `Get-WattTime` function now converts the `string` to an `int`.

## Related Issue

This fixes #19 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
